### PR TITLE
Encode numpy datatypes in dataframe to JSON

### DIFF
--- a/vecorel_cli/encoding/geojson.py
+++ b/vecorel_cli/encoding/geojson.py
@@ -336,5 +336,9 @@ class VecorelJSONEncoder(json.JSONEncoder):
             return obj.tolist()
         elif isinstance(obj, set):
             return list(obj)
+        elif isinstance(obj, np.integer):
+            return int(obj)
+        elif isinstance(obj, np.bool):
+            return bool(obj)
         else:
             return super().default(obj)

--- a/vecorel_cli/encoding/geojson.py
+++ b/vecorel_cli/encoding/geojson.py
@@ -336,9 +336,7 @@ class VecorelJSONEncoder(json.JSONEncoder):
             return obj.tolist()
         elif isinstance(obj, set):
             return list(obj)
-        elif isinstance(obj, np.integer):
-            return int(obj)
-        elif isinstance(obj, np.bool):
-            return bool(obj)
+        elif isinstance(obj, np.generic):
+            return obj.item()
         else:
             return super().default(obj)


### PR DESCRIPTION
If the GeoDataFrame contains columns of type `numpy.int32` (or any other `numpy.int` type), or a `numpy.bool`, then we get errors like:

```
FAILED tests/test_convert.py::test_converter[hr] - TypeError: Object of type int32 is not JSON serializable
FAILED tests/test_convert.py::test_converter[jecam] - TypeError: Object of type bool is not JSON serializable
```
